### PR TITLE
feat: AddPostgresCli-#12 Postgres用クライアントモジュール追加

### DIFF
--- a/backend/ark/omega/storage/psql.go
+++ b/backend/ark/omega/storage/psql.go
@@ -1,0 +1,37 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	_ "github.com/golang-migrate/migrate/v4/database/postgres"
+	"github.com/jmoiron/sqlx"
+)
+
+func NewPostgres(dsn string) (db *sqlx.DB, err error) {
+	ctx := context.Background()
+	{
+		timeout, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		db, err = sqlx.ConnectContext(timeout, "postgres", dsn)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer func() {
+		if err != nil {
+			db.Close()
+		}
+	}()
+
+	{
+		timeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err = db.PingContext(timeout); err != nil {
+			return nil, fmt.Errorf("connection timeout: %s ", err)
+		}
+	}
+
+	return db, nil
+}


### PR DESCRIPTION
DBクライアントに渡すsqlx.DBをDBの種類毎に分けるので専用のモジュールを定義

ドライバーライブラリをimportする必要がありそうなのでDB毎にモジュールを定義