### PR TITLE
refactor: RefactorVariantsClient-#12 クエリ実行を汎用クライアント処理に移譲

### DIFF
--- a/backend/ark/omega/storage/variants.go
+++ b/backend/ark/omega/storage/variants.go
@@ -2,10 +2,7 @@ package storage
 
 import (
 	"context"
-	"database/sql"
-	"errors"
-	"fmt"
-	"time"
+	"log/slog"
 
 	"github.com/jmoiron/sqlx"
 
@@ -14,23 +11,16 @@ import (
 )
 
 type VariantClient struct {
-	*sqlx.DB
+	*Client[variantModel, int]
 }
 
-func NewVariantClient(dsn string) (service.VariantRepository, error) {
-	db, err := sqlx.Open("postgres", dsn)
+func NewVariantClient(db *sqlx.DB, logger *slog.Logger) (service.VariantRepository, error) {
+	cli, err := Connect[variantModel, int](db, logger)
 	if err != nil {
 		return nil, err
 	}
-
-	timeout, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-	if err = db.PingContext(timeout); err != nil {
-		return nil, fmt.Errorf("connection timeout: %s ", err)
-	}
-
 	return VariantClient{
-		DB: db,
+		cli,
 	}, nil
 }
 
@@ -42,20 +32,13 @@ type variantModel struct {
 }
 
 func (v VariantClient) FindVariant(ctx context.Context, id model.VariantID) (*model.Variant, error) {
-	query, args, err := v.BindNamed(
+	row, err := v.NamedGet(
+		ctx,
 		`SELECT variants.id, variants.name, groups.name AS "group" FROM variants
     INNER JOIN groups ON (variants.group_id = groups.id) WHERE variants.id = :id;`,
 		map[string]any{"id": id},
 	)
-
 	if err != nil {
-		return nil, err
-	}
-
-	var row variantModel
-	if err = v.GetContext(ctx, &row, query, args...); errors.Is(err, sql.ErrNoRows) {
-		return nil, service.NotFound
-	} else if err != nil {
 		return nil, err
 	}
 
@@ -68,13 +51,12 @@ func (v VariantClient) FindVariant(ctx context.Context, id model.VariantID) (*mo
 }
 
 func (v VariantClient) ListVariants(ctx context.Context) (model.Variants, error) {
-	query := `SELECT variants.id, variants.name, groups.name AS "group" FROM variants
-    INNER JOIN groups ON (variants.group_id = groups.id);`
-
-	var rows []variantModel
-	if err := v.SelectContext(ctx, &rows, query); errors.Is(err, sql.ErrNoRows) {
-		return nil, service.NotFound
-	} else if err != nil {
+	rows, err := v.NamedSelect(
+		ctx,
+		`SELECT variants.id, variants.name, groups.name AS "group" FROM variants
+    INNER JOIN groups ON (variants.group_id = groups.id);`,
+	)
+	if err != nil {
 		return nil, err
 	}
 
@@ -94,18 +76,11 @@ func (v VariantClient) ListVariants(ctx context.Context) (model.Variants, error)
 }
 
 func (v VariantClient) CreateVariant(ctx context.Context, create service.CreateVariant) (*model.Variant, error) {
-	stmt, err := v.PrepareNamedContext(
+	id, err := v.NamedStore(
 		ctx,
 		`INSERT INTO variants (name, group_id) VALUES (:name, :groupID) RETURNING id;`,
+		map[string]any{"name": create.Name(), "groupID": create.GroupID()},
 	)
-	if err != nil {
-		return nil, err
-	}
-
-	var id int
-	err = stmt.
-		QueryRowxContext(ctx, map[string]any{"name": create.Name(), "groupID": create.GroupID()}).
-		Scan(&id)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +94,8 @@ func (v VariantClient) CreateVariant(ctx context.Context, create service.CreateV
 }
 
 func (v VariantClient) UpdateVariant(ctx context.Context, update service.UpdateVariant) (*model.Variant, error) {
-	query, args, err := v.BindNamed(
+	id, err := v.NamedStore(
+		ctx,
 		`UPDATE variants SET name = :name, group_id = :groupID, updated_at = NOW() WHERE id = :id RETURNING id;`,
 		map[string]any{"id": update.ID(), "name": update.Name(), "groupID": update.GroupID()},
 	)
@@ -127,12 +103,7 @@ func (v VariantClient) UpdateVariant(ctx context.Context, update service.UpdateV
 		return nil, err
 	}
 
-	_, err = v.ExecContext(ctx, query, args...)
-	if err != nil {
-		return nil, err
-	}
-
-	result, err := v.FindVariant(ctx, update.ID())
+	result, err := v.FindVariant(ctx, model.VariantID(id))
 	if err != nil {
 		return nil, err
 	}
@@ -140,10 +111,5 @@ func (v VariantClient) UpdateVariant(ctx context.Context, update service.UpdateV
 	return result, nil
 }
 func (v VariantClient) DeleteVariant(ctx context.Context, id model.VariantID) error {
-	_, err := v.NamedExecContext(
-		ctx,
-		`DELETE FROM variants WHERE id = :id;`,
-		map[string]any{"id": id},
-	)
-	return err
+	return v.NamedDelete(ctx, `DELETE FROM variants WHERE id = :id;`, map[string]any{"id": id})
 }


### PR DESCRIPTION
実行するクエリや引数の定義とレコードのドメインモデルへのバインドに専念