### PR TITLE
feat: AddTransactionInterface-#19 トランザクションの抽象化を行うインターフェースを定義

### DIFF
--- a/backend/ark/omega/logic/transaction.go
+++ b/backend/ark/omega/logic/transaction.go
@@ -1,0 +1,50 @@
+package logic
+
+import "context"
+
+type Transactioner interface {
+	WithTransaction(ctx context.Context, fn func(context.Context) (any, error)) (any, error)
+}
+
+type txerKey struct{}
+
+func SetTransctioner(ctx context.Context, tx Transactioner) context.Context {
+	return context.WithValue(ctx, txerKey{}, tx)
+}
+
+func GetTransctioner(ctx context.Context) (Transactioner, bool) {
+	v := ctx.Value(txerKey{})
+	if v != nil {
+		return v.(Transactioner), true
+	}
+	return nil, false
+}
+
+// UseTransactioner 戻り値にデータもあるINSERTなどの処理に用いる
+func UseTransactioner[R any](ctx context.Context, fn func(ctx context.Context) (R, error)) (_ R, err error) {
+	tx, ok := GetTransctioner(ctx)
+	if !ok {
+		return fn(ctx)
+	}
+	res, err := tx.WithTransaction(ctx, func(ctx context.Context) (any, error) {
+		return fn(ctx)
+	})
+	if err != nil {
+		return
+	}
+
+	return res.(R), nil
+}
+
+// UseTransactioner0 戻り値がエラーのみのDELETEなどの処理に用いる
+func UseTransactioner0(ctx context.Context, fn func(ctx context.Context) error) error {
+	tx, ok := GetTransctioner(ctx)
+	if !ok {
+		return fn(ctx)
+	}
+	_, err := tx.WithTransaction(ctx, func(ctx context.Context) (any, error) {
+		return nil, fn(ctx)
+	})
+
+	return err
+}


### PR DESCRIPTION
何もしないトランザクション実装を注入することでロジックのテストのみできるようにする

トランザクションに囲みたいロジック処理を受け取る
コンテキストからトランザクションを取り出してロジックを受け取り実行
コンテキストへのトランザクション実装のセッターおよびゲッター定義