### PR TITLE
feat: AddUsecaseTransaction-#19 トランザクションを注入するミドルウェアを定義

### DIFF
--- a/backend/ark/omega/logic/transaction.go
+++ b/backend/ark/omega/logic/transaction.go
@@ -8,7 +8,7 @@ type Transactioner interface {
 
 type txerKey struct{}
 
-func SetTransctioner(ctx context.Context, tx Transactioner) context.Context {
+func SetTransactioner(ctx context.Context, tx Transactioner) context.Context {
 	return context.WithValue(ctx, txerKey{}, tx)
 }
 

--- a/backend/ark/omega/server/handlers/middleware.go
+++ b/backend/ark/omega/server/handlers/middleware.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"mods-explore/ark/omega/storage"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -44,6 +45,17 @@ func NewErrorHandler(s *echo.Echo) func(err error, c echo.Context) {
 					c.Logger().Error(err)
 				}
 			}
+		}
+	}
+}
+
+func Transctioner[T any, ID any](cli *storage.Client[T, ID]) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			ctx := c.Request().Context()
+			ctx = logic.SetTransactioner(ctx, cli)
+			c.SetRequest(c.Request().WithContext(ctx))
+			return next(c)
 		}
 	}
 }

--- a/backend/ark/omega/server/server.go
+++ b/backend/ark/omega/server/server.go
@@ -70,6 +70,7 @@ func newServer(conf omega.DBConfig) (*echo.Echo, error) {
 			return nil, err
 		}
 
+		variantsV1.Use(handlers.Transctioner(repoClient.(storage.VariantClient).Client))
 		handler := handlers.NewVariant(usecase.NewVariant(repoClient))
 		variantsV1.GET("/:id", handler.Read)
 		variantsV1.GET("", handler.List)
@@ -85,6 +86,7 @@ func newServer(conf omega.DBConfig) (*echo.Echo, error) {
 			return nil, err
 		}
 
+		variantsV1.Use(handlers.Transctioner(repoClient.(storage.VariantGroupClient).Client))
 		handler := handlers.NewVariantGroup(usecase.NewVariantGroup(repoClient))
 		variantGroupsV1.GET("/:id", handler.Read)
 		variantGroupsV1.GET("", handler.List)


### PR DESCRIPTION
トランザクションの取得に各テーブルクライアントが必要なので初期化後にミドルウェア生成関数に渡す