### PR TITLE
fix: FixTxRollbackPanic-#25 deferでエラーを引数で受け取りパニックしないように修正

### DIFF
--- a/backend/ark/omega/storage/transaction.go
+++ b/backend/ark/omega/storage/transaction.go
@@ -18,7 +18,7 @@ func (c *Client[T, ID]) WithTransaction(ctx context.Context, fn func(context.Con
 		return nil, err
 	}
 
-	defer func() {
+	defer func(err error) {
 		if p := recover(); p != nil {
 			if err = tx.Rollback(); err != nil {
 				c.logger.ErrorContext(ctx, "failed to rollback transaction in panic", slog.Any("error", err))
@@ -34,7 +34,7 @@ func (c *Client[T, ID]) WithTransaction(ctx context.Context, fn func(context.Con
 		if err = tx.Commit(); err != nil {
 			c.logger.ErrorContext(ctx, "failed to commit transaction", slog.Any("error", err))
 		}
-	}()
+	}(err)
 
 	return fn(SetTx(timeout, tx))
 }


### PR DESCRIPTION
deferの変数は定義時に評価されるので、名前付き戻り値の場合nilが入ってしまうので引数で実行時の値を受け取るように修正