### PR TITLE
refactor: RefactorTxToContext-#33 トランザクション注入関数修正

### DIFF
--- a/backend/ark/omega/server/handlers/middleware.go
+++ b/backend/ark/omega/server/handlers/middleware.go
@@ -1,13 +1,14 @@
 package handlers
 
 import (
-	"mods-explore/ark/omega/storage"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
 	"github.com/morikuni/failure"
+	"github.com/samber/do"
 
 	"mods-explore/ark/omega/logic"
+	"mods-explore/ark/omega/storage"
 )
 
 func NewErrorHandler(s *echo.Echo) func(err error, c echo.Context) {
@@ -49,11 +50,11 @@ func NewErrorHandler(s *echo.Echo) func(err error, c echo.Context) {
 	}
 }
 
-func Transctioner[T any, ID any](cli *storage.Client[T, ID]) echo.MiddlewareFunc {
+func Transctioner[T any, ID any](injector *do.Injector) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			ctx := c.Request().Context()
-			ctx = logic.SetTransactioner(ctx, cli)
+			ctx = logic.SetTransactioner(ctx, do.MustInvoke[*storage.Client[T, ID]](injector))
 			c.SetRequest(c.Request().WithContext(ctx))
 			return next(c)
 		}

--- a/backend/ark/omega/server/server.go
+++ b/backend/ark/omega/server/server.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"mods-explore/ark/omega"
-	"mods-explore/ark/omega/logic/variant/domain/service"
 	"mods-explore/ark/omega/logic/variant/usecase"
 	"mods-explore/ark/omega/server/handlers"
 	"mods-explore/ark/omega/storage"
@@ -49,13 +48,11 @@ func newServer(injector *do.Injector) (*echo.Echo, error) {
 		return c.String(http.StatusOK, "I'm fine!")
 	})
 
-	variantsV1 := s.Group("/api/v1/variants")
+	variantsV1 := s.Group(
+		"/api/v1/variants",
+		handlers.Transctioner[storage.VariantModel, int](injector),
+	)
 	{ // variant
-		variantsV1.Use(
-			handlers.Transctioner(
-				do.MustInvoke[service.VariantRepository](injector).(storage.VariantClient).Client,
-			),
-		)
 		handler := do.MustInvoke[handlers.VariantHandler](injector)
 		variantsV1.GET("/:id", handler.Read)
 		variantsV1.GET("", handler.List)
@@ -64,13 +61,11 @@ func newServer(injector *do.Injector) (*echo.Echo, error) {
 		variantsV1.DELETE("/:id", handler.Delete)
 	}
 
-	variantGroupsV1 := s.Group("/api/v1/variant-groups")
+	variantGroupsV1 := s.Group(
+		"/api/v1/variant-groups",
+		handlers.Transctioner[storage.VariantGroupModel, int](injector),
+	)
 	{ // variant group
-		variantsV1.Use(
-			handlers.Transctioner(
-				do.MustInvoke[service.VariantGroupRepository](injector).(storage.VariantGroupClient).Client,
-			),
-		)
 		handler := do.MustInvoke[handlers.VariantGroupHandler](injector)
 		variantGroupsV1.GET("/:id", handler.Read)
 		variantGroupsV1.GET("", handler.List)


### PR DESCRIPTION
トランザクション初期化処理の内部でテーブルクライアントを取得するように修正
グループ毎にテーブルクライアントの型を指定して適切な型のインスタンスを注入するようにする