### PR TITLE
Add variant usecase test #40

### DIFF
--- a/backend/ark/omega/logic/variant/usecase/mocks.go
+++ b/backend/ark/omega/logic/variant/usecase/mocks.go
@@ -1,0 +1,72 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+
+	"mods-explore/ark/omega/logic"
+	"mods-explore/ark/omega/logic/variant/domain/model"
+	"mods-explore/ark/omega/logic/variant/domain/service"
+)
+
+// mockTransactionがインターフェースを満たしているか
+var _ logic.Transactioner = (*mockDBClient)(nil)
+var _ service.VariantRepository = (*mockDBClient)(nil)
+
+type mockDBClient struct {
+	mock.Mock
+}
+
+func newMockDBClient() *mockDBClient { return &mockDBClient{} }
+
+func (c *mockDBClient) WithTransaction(ctx context.Context, fn func(context.Context) (any, error)) (any, error) {
+	return fn(ctx)
+}
+
+func (c *mockDBClient) FindVariant(ctx context.Context, id model.VariantID) (*model.Variant, error) {
+	args := c.Called(ctx, id)
+
+	r := args.Get(0)
+	if r == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.Variant), args.Error(1)
+}
+
+func (c *mockDBClient) ListVariants(ctx context.Context) (model.Variants, error) {
+	args := c.Called(ctx)
+
+	r := args.Get(0)
+	if r == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(model.Variants), nil
+}
+func (c *mockDBClient) CreateVariant(ctx context.Context, create service.CreateVariant) (*model.Variant, error) {
+	args := c.Called(ctx, create)
+
+	r := args.Get(0)
+	if r == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.Variant), args.Error(1)
+}
+func (c *mockDBClient) UpdateVariant(ctx context.Context, update service.UpdateVariant) (*model.Variant, error) {
+	args := c.Called(ctx, update)
+
+	r := args.Get(0)
+	if r == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.Variant), args.Error(1)
+}
+func (c *mockDBClient) DeleteVariant(ctx context.Context, id model.VariantID) error {
+	args := c.Called(ctx, id)
+
+	r := args.Get(0)
+	if r == nil {
+		return nil
+	}
+	return args.Error(0)
+}

--- a/backend/ark/omega/logic/variant/usecase/variant_test.go
+++ b/backend/ark/omega/logic/variant/usecase/variant_test.go
@@ -1,0 +1,256 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/morikuni/failure"
+	"github.com/samber/do"
+	"github.com/stretchr/testify/suite"
+
+	"mods-explore/ark/omega/logic"
+	"mods-explore/ark/omega/logic/variant/domain/model"
+	"mods-explore/ark/omega/logic/variant/domain/service"
+)
+
+type VariantTestSuite struct {
+	suite.Suite
+
+	mockDB  *mockDBClient
+	usecase VariantUsecase
+}
+
+func newTestVariantSuite() *VariantTestSuite { return &VariantTestSuite{} }
+
+func TestVariantSuite(t *testing.T) {
+	suite.Run(t, newTestVariantSuite())
+}
+
+var (
+	ctx = context.Background()
+	e   = errors.New("test")
+)
+
+const (
+	find   = "FindVariant"
+	list   = "ListVariants"
+	create = "CreateVariant"
+	update = "UpdateVariant"
+	delete = "DeleteVariant"
+)
+
+const (
+	id = iota
+	notExistID
+	intervalServerErrID
+	errID
+)
+
+const (
+	groupID = iota
+)
+
+func (s *VariantTestSuite) SetupSuite() {
+	injector := do.New()
+
+	mockDB := newMockDBClient()
+	do.ProvideValue[service.VariantRepository](injector, mockDB)
+	s.mockDB = mockDB
+	usecase, err := NewVariant(injector)
+	if err != nil {
+		return
+	}
+
+	s.usecase = usecase
+}
+
+func (s *VariantTestSuite) TestFind() {
+	variant := model.NewVariant(model.VariantID(id), "cosmic", "meteor")
+	{
+		s.mockDB.On(
+			find,
+			ctx,
+			model.VariantID(id),
+		).
+			Return(&variant, nil)
+		r, err := s.usecase.Find(ctx, model.VariantID(id))
+		if err != nil {
+			s.T().Error(err)
+			return
+		}
+
+		s.Equal(&variant, r)
+	}
+	{
+		s.mockDB.On(
+			find,
+			ctx,
+			model.VariantID(notExistID),
+		).
+			Return(nil, service.NotFound)
+		_, err := s.usecase.Find(ctx, model.VariantID(notExistID))
+		s.True(failure.Is(err, logic.NotFound))
+	}
+	{
+		s.mockDB.On(
+			find,
+			ctx,
+			model.VariantID(intervalServerErrID),
+		).
+			Return(nil, service.IntervalServerError)
+		_, err := s.usecase.Find(ctx, model.VariantID(intervalServerErrID))
+		s.True(failure.Is(err, logic.IntervalServerError))
+	}
+	{
+		s.mockDB.On(
+			find,
+			ctx,
+			model.VariantID(errID),
+		).
+			Return(nil, failure.Wrap(e))
+		_, err := s.usecase.Find(ctx, model.VariantID(errID))
+		s.True(errors.Is(err, e))
+	}
+}
+
+func (s *VariantTestSuite) TestList() {
+	variants := model.Variants{
+		model.NewVariant(model.VariantID(id), "cosmic", "meteor"),
+	}
+
+	{
+		s.mockDB.On(
+			list,
+			ctx,
+		).
+			Return(variants, nil).
+			Once()
+		r, err := s.usecase.List(ctx)
+		if err != nil {
+			s.T().Error(err)
+			return
+		}
+
+		s.Equal(variants, r)
+	}
+	{
+		s.mockDB.On(
+			list,
+			ctx,
+		).
+			Return(nil, service.IntervalServerError).
+			Once()
+		_, err := s.usecase.List(ctx)
+		s.True(failure.Is(err, logic.IntervalServerError))
+	}
+	{
+		s.mockDB.On(
+			list,
+			ctx,
+		).
+			Return(nil, failure.Wrap(e)).
+			Once()
+		_, err := s.usecase.List(ctx)
+		s.True(errors.Is(err, e))
+	}
+}
+
+func (s *VariantTestSuite) TestCreate() {
+	item := service.NewCreateVariant(groupID, "meteor")
+	variant := model.NewVariant(id, "cosmic", "meteor")
+	{
+		s.mockDB.On(
+			create,
+			ctx,
+			item,
+		).
+			Return(&variant, nil).
+			Once()
+		r, err := s.usecase.Create(ctx, item)
+		if err != nil {
+			s.T().Error(err)
+			return
+		}
+
+		s.Equal(&variant, r)
+	}
+	{
+		s.mockDB.On(
+			create,
+			ctx,
+			item,
+		).
+			Return(nil, e).
+			Once()
+		_, err := s.usecase.Create(ctx, item)
+		s.True(errors.Is(err, e))
+	}
+}
+
+// TestUpdate レコードの存在確認はFindと同じなのチェックしない
+func (s *VariantTestSuite) TestUpdate() {
+	{
+		item := service.NewUpdateVariant(id, groupID, "meteor")
+		variant := model.NewVariant(id, "cosmic", "meteor")
+		s.mockDB.On(find, model.VariantID(id)).Return(&variant, nil).Once()
+		s.mockDB.On(
+			update,
+			ctx,
+			item,
+		).
+			Return(&variant, nil).
+			Once()
+		r, err := s.usecase.Update(ctx, item)
+		if err != nil {
+			s.T().Error(err)
+			return
+		}
+
+		s.Equal(&variant, r)
+	}
+
+	{ // update error case
+		item := service.NewUpdateVariant(id, groupID, "meteor")
+		variant := model.NewVariant(id, "cosmic", "meteor")
+		s.mockDB.On(find, model.VariantID(id)).Return(&variant, nil).Once()
+		s.mockDB.On(
+			update,
+			ctx,
+			item,
+		).
+			Return(nil, e).
+			Once()
+		_, err := s.usecase.Update(ctx, item)
+		s.True(errors.Is(err, e))
+	}
+}
+
+func (s *VariantTestSuite) TestDelete() {
+	{
+		variant := model.NewVariant(id, "cosmic", "meteor")
+		s.mockDB.On(find, ctx, model.VariantID(id)).Return(&variant, nil).Once()
+		s.mockDB.On(
+			delete,
+			ctx,
+			model.VariantID(id),
+		).
+			Return(nil).
+			Once()
+		s.Nil(s.usecase.Delete(ctx, model.VariantID(id)))
+	}
+
+	{ // update error case
+		variant := model.NewVariant(id, "cosmic", "meteor")
+		s.mockDB.On(find, ctx, model.VariantID(id)).Return(&variant, nil).Once()
+		s.mockDB.On(
+			delete,
+			ctx,
+			model.VariantID(id),
+		).
+			Return(e).
+			Once()
+		err := s.usecase.Delete(ctx, model.VariantID(id))
+		s.True(errors.Is(err, e))
+	}
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/samber/do v1.6.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/zhashkevych/go-sqlxmock v1.5.2-0.20201023121933-f973d0041cfc // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -88,8 +88,13 @@ github.com/samber/lo v1.39.0/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXn
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=


### PR DESCRIPTION
testifyを用いたテストを追加
ユースケースに必要なリポジトリの依存性をモックを用いて注入。
モックにはlogic.Transactioner, service.VariantRepositoryを実装。