### PR TITLE
refactor: RefactorUniqueUsecaseCommand-#7 コマンドのInsert処理時にユニークキーを戻り値にするように修正

### DIFF
--- a/backend/ark/omega/logic/creature/domain/service/dinosaur.go
+++ b/backend/ark/omega/logic/creature/domain/service/dinosaur.go
@@ -7,7 +7,7 @@ import (
 )
 
 type DinosaurCommandRepository interface {
-	Insert(context.Context, CreateDinosaur) error
+	Insert(context.Context, CreateDinosaur) (model.DinosaurID, error)
 	Update(context.Context, UpdateDinosaur) error
 	Delete(context.Context, model.DinosaurID) error
 }

--- a/backend/ark/omega/logic/creature/domain/service/unique.go
+++ b/backend/ark/omega/logic/creature/domain/service/unique.go
@@ -13,8 +13,8 @@ type UniqueQueryRepository interface {
 }
 
 type UniqueCommandRepository interface {
-	Insert(context.Context, CreateUniqueDinosaur) (*ResponseUnique, error)
-	Update(context.Context, UpdateUniqueDinosaur) (*ResponseUnique, error)
+	Insert(context.Context, CreateUniqueDinosaur) (model.UniqueDinosaurID, error)
+	Update(context.Context, UpdateUniqueDinosaur) error
 	Delete(context.Context, model.UniqueDinosaurID) error
 }
 

--- a/backend/ark/omega/logic/creature/domain/service/variant.go
+++ b/backend/ark/omega/logic/creature/domain/service/variant.go
@@ -7,8 +7,8 @@ import (
 )
 
 type VariantsCommandRepository interface {
-	Insert(context.Context, CreateVariants) (*ResponseVariants, error)
-	Update(context.Context, UpdateVariants) (*ResponseVariants, error)
+	Insert(context.Context, CreateVariants) (model.UniqueVariantID, error)
+	Update(context.Context, UpdateVariants) error
 	Delete(context.Context, model.UniqueVariantID) error
 }
 


### PR DESCRIPTION
レコード作成処理でInsert後のIDが後の処理に必要になるのでIDを戻す

ユニーク生物のレコードにユニークバリアントのIDと生物のIDを一緒に格納する必要があるので戻り値に設定 ユニーク生物レコード格納後にIDでSelectするのでIDを戻すように修正